### PR TITLE
Fix index out-of-range error

### DIFF
--- a/clix/parsers/hammer.py
+++ b/clix/parsers/hammer.py
@@ -36,8 +36,9 @@ class Hammer:
             elif line and category == "sub commands":
                 sub_commands.append(line.strip().split()[0])
             elif "--" in line and category == "options":
-                line = line.split("--")[1]
-                options.append(line.split()[0])
+                line = line.split("--")[1].split()
+                if line:
+                    options.append(line[0])
             elif line == "Subcommands:":
                 logger.debug("Changing category to subcommands.")
                 category = "sub commands"


### PR DESCRIPTION
Hello

this fixes
`clix/parsers/hammer.py", line 40, in process_help_text
    options.append(line.split()[0])
IndexError: list index out of range`
